### PR TITLE
Fix: Changed Directory to composer autoload file

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,7 +1,7 @@
 <?php
 
 // Include Composer autoload file to load Resend SDK classes...
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/vendor/autoload.php';
 
 // Assign a new Resend Client instance to $resend variable, which is automatically autoloaded...
 $resend = Resend::client('re_123456789');


### PR DESCRIPTION
Current directory for including Composer autoload file is invalid when following the Readme and leads to an error when running `php -S 127.0.0.1:8000`. 

This fix updates the directory for the autoload file for `php -S 127.0.0.1:8000` to run successfully.